### PR TITLE
Add FSMN block implementation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # codex_fsmn2
+
+This repository provides reference implementations and utilities for building
+Feedforward Sequential Memory Network (FSMN) components in PyTorch.
+
+## FSMN block
+
+The :class:`fsmn.FSMNBlock` wraps the memory filter, projection, and residual
+connections described in the original FSMN architecture. Inputs are shaped as
+``(batch, time, feature)`` tensors and a combination of left and right context
+is applied through a learnable tapped-delay line.
+
+```python
+import torch
+from fsmn import FSMNBlock
+
+block = FSMNBlock(
+    input_size=64,
+    hidden_size=128,
+    left_context=3,
+    right_context=1,
+    stride=1,
+)
+
+inputs = torch.randn(8, 120, 64)
+outputs = block(inputs)
+assert outputs.shape == inputs.shape
+```
+
+The memory kernel can be tuned by adjusting the ``left_context``,
+``right_context``, and ``stride`` arguments. Set ``use_residual=False`` when you
+only need the filtered activations without adding the input back in. By default
+an activation (ReLU) and dropout layer are applied between the feedforward and
+projection stages, but these can be customized via the ``activation`` and
+``dropout`` arguments.

--- a/fsmn/__init__.py
+++ b/fsmn/__init__.py
@@ -1,0 +1,5 @@
+"""FSMN building blocks."""
+
+from .block import FSMNBlock
+
+__all__ = ["FSMNBlock"]

--- a/fsmn/block.py
+++ b/fsmn/block.py
@@ -1,0 +1,104 @@
+"""Building blocks for feedforward sequential memory networks."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+
+class FSMNBlock(nn.Module):
+    """Feedforward Sequential Memory Network (FSMN) block.
+
+    The block consumes inputs shaped ``(batch, time, feature)`` and applies
+    a learned tapped-delay memory filter with optional left/right context and
+    stride. The filtered representation is added to a feedforward projection and
+    returned with a residual connection to the input.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        *,
+        left_context: int,
+        right_context: int = 0,
+        stride: int = 1,
+        activation: Optional[nn.Module] = None,
+        dropout: float = 0.0,
+        use_residual: bool = True,
+    ) -> None:
+        super().__init__()
+        if left_context < 0:
+            raise ValueError("left_context must be >= 0")
+        if right_context < 0:
+            raise ValueError("right_context must be >= 0")
+        if stride < 1:
+            raise ValueError("stride must be >= 1")
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.left_context = left_context
+        self.right_context = right_context
+        self.stride = stride
+        self.use_residual = use_residual
+
+        self.ff = nn.Linear(input_size, hidden_size)
+        self.activation = activation if activation is not None else nn.ReLU()
+        self.dropout = nn.Dropout(dropout)
+        self.proj = nn.Linear(hidden_size, input_size)
+
+        total_context = left_context + right_context + 1
+        self.memory_kernel = nn.Parameter(torch.zeros(hidden_size, total_context))
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        """Apply the FSMN block.
+
+        Args:
+            inputs: Tensor with shape ``(batch, time, feature)``.
+
+        Returns:
+            Tensor with the same shape as ``inputs``.
+        """
+
+        if inputs.dim() != 3:
+            raise ValueError("FSMNBlock expects a 3D tensor (batch, time, feature)")
+        if inputs.size(-1) != self.input_size:
+            raise ValueError(
+                f"Expected input feature dimension {self.input_size}, "
+                f"but received {inputs.size(-1)}"
+            )
+
+        residual = inputs
+        hidden = self.ff(inputs)
+        if self.activation is not None:
+            hidden = self.activation(hidden)
+        hidden = hidden + self._apply_memory(hidden)
+        hidden = self.dropout(hidden)
+        output = self.proj(hidden)
+        if self.use_residual:
+            output = output + residual
+        return output
+
+    def _apply_memory(self, hidden: torch.Tensor) -> torch.Tensor:
+        """Apply the learnable memory kernel over time."""
+
+        if self.left_context == 0 and self.right_context == 0:
+            weights = self.memory_kernel[:, 0].view(1, 1, -1)
+            return hidden * weights
+
+        contexts = []
+        offsets = range(-self.left_context, self.right_context + 1)
+        for offset in offsets:
+            shift = offset * self.stride
+            if shift < 0:
+                shifted = F.pad(hidden[:, : shift, :], (0, 0, -shift, 0))
+            elif shift > 0:
+                shifted = F.pad(hidden[:, shift:, :], (0, 0, 0, shift))
+            else:
+                shifted = hidden
+            contexts.append(shifted)
+        stacked = torch.stack(contexts, dim=-1)  # (batch, time, feat, contexts)
+        memory = torch.einsum("btfc,fc->btf", stacked, self.memory_kernel)
+        return memory

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,0 +1,63 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch import nn
+
+from fsmn import FSMNBlock
+
+
+def test_forward_shape_preserved():
+    block = FSMNBlock(input_size=8, hidden_size=12, left_context=2, right_context=1)
+    inputs = torch.randn(3, 11, 8)
+    outputs = block(inputs)
+    assert outputs.shape == inputs.shape
+
+
+def test_residual_connection_identity():
+    block = FSMNBlock(input_size=4, hidden_size=6, left_context=1, right_context=1)
+    with torch.no_grad():
+        block.ff.weight.zero_()
+        block.ff.bias.zero_()
+        block.proj.weight.zero_()
+        block.proj.bias.zero_()
+        block.memory_kernel.zero_()
+    inputs = torch.randn(2, 5, 4)
+    outputs = block(inputs)
+    assert torch.allclose(outputs, inputs)
+
+
+def test_memory_kernel_matches_reference():
+    block = FSMNBlock(
+        input_size=3,
+        hidden_size=3,
+        left_context=1,
+        right_context=1,
+        stride=1,
+        activation=nn.Identity(),
+        use_residual=False,
+    )
+    with torch.no_grad():
+        block.ff.weight.copy_(torch.eye(3))
+        block.ff.bias.zero_()
+        block.proj.weight.copy_(torch.eye(3))
+        block.proj.bias.zero_()
+        kernel = torch.tensor(
+            [[0.2, 0.5, -0.1], [-0.3, 0.4, 0.6], [0.0, -0.2, 0.8]], dtype=torch.float32
+        )
+        block.memory_kernel.copy_(kernel)
+
+    inputs = torch.tensor(
+        [[[1.0, 0.0, -1.0], [0.5, -0.5, 0.5], [0.0, 1.0, 1.0]]], dtype=torch.float32
+    )
+    outputs = block(inputs)
+
+    expected = torch.zeros_like(inputs)
+    offsets = [-1, 0, 1]
+    for t in range(inputs.size(1)):
+        for idx, offset in enumerate(offsets):
+            src = t + offset
+            if 0 <= src < inputs.size(1):
+                expected[:, t] += inputs[:, src] * kernel[:, idx]
+    expected = inputs + expected
+
+    assert torch.allclose(outputs, expected, atol=1e-6, rtol=1e-5)


### PR DESCRIPTION
## Summary
- implement an FSMNBlock module with configurable memory filters, projection, and residual connection
- expose the block from the fsmn package and document usage in the README
- add tests that validate shapes, residual identity, and memory kernel behaviour (skipped if PyTorch is unavailable)

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0ba7578cc832f85a08399e6b46044